### PR TITLE
Remove console raw mode workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,18 +243,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "regex",
- "terminal_size",
  "unicode-width",
- "winapi",
- "winapi-util",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1636,16 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,19 +2044,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2085,9 +2096,9 @@ checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2103,9 +2114,9 @@ checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2121,9 +2132,9 @@ checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2139,15 +2150,15 @@ checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2163,9 +2174,9 @@ checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = { version = "0.11.10", features = ["blocking", "json"] }
 minimp3 = "0.5.1"
 clap = { version = "3.1.18", features = ["derive"] }
 indicatif = "0.17.1"
-console = "0.15.0"
+console = "0.15.7"
 colored = "2.0.0"
 version-compare = "0.1.0"
 inquire = { version = "0.6.1", default-features = false, features = ["console"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use model::{CodeRadioMessage, Remote};
 use player::Player;
 use rodio::Source;
 use std::{fmt::Write, sync::Mutex, thread, time::Duration};
-use terminal::writeline;
 use tokio::{net::TcpStream, time::sleep};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
@@ -36,7 +35,7 @@ async fn main() {
     let _terminal_clean_up_helper = terminal::create_clean_up_helper(); // See the comments in "terminal" module
 
     if let Err(e) = start().await {
-        writeline!();
+        println!();
         terminal::print_error(e);
     }
 }
@@ -82,7 +81,7 @@ async fn start_playing(args: Args) -> Result<()> {
         }
         Err(e) => {
             terminal::print_error(e);
-            writeline!();
+            println!();
         }
     }
 
@@ -109,17 +108,17 @@ async fn start_playing(args: Args) -> Result<()> {
     // Notify user if a new version is available
     if update_checking_task.is_finished() {
         if let Ok(Ok(Some(new_release))) = update_checking_task.await {
-            writeline!(
+            println!(
                 "{}",
                 format!("New version available: {}", new_release.version).bright_yellow()
             );
-            writeline!("{}", new_release.url.bright_yellow());
-            writeline!();
+            println!("{}", new_release.url.bright_yellow());
+            println!();
         }
     }
 
     if let Some(station) = stations.iter().find(|station| station.url == listen_url) {
-        writeline!("{}    {}", "Station:".bright_green(), station.name);
+        println!("{}    {}", "Station:".bright_green(), station.name);
     }
 
     if let Some(player) = PLAYER.lock().unwrap().as_ref() {
@@ -161,11 +160,11 @@ Run {} to get more help.",
     );
 
     if !args.no_logo {
-        writeline!("{}", logo);
-        writeline!();
+        println!("{}", logo);
+        println!();
     }
-    writeline!("{}", description);
-    writeline!();
+    println!("{}", description);
+    println!();
 }
 
 async fn get_next_websocket_message(
@@ -241,10 +240,10 @@ fn update_song_info_on_screen(message: CodeRadioMessage, last_song_id: &mut Stri
 
         *last_song_id = song.id.clone();
 
-        writeline!();
-        writeline!("{}       {}", "Song:".bright_green(), song.title);
-        writeline!("{}     {}", "Artist:".bright_green(), song.artist);
-        writeline!("{}      {}", "Album:".bright_green(), song.album);
+        println!();
+        println!("{}       {}", "Song:".bright_green(), song.title);
+        println!("{}     {}", "Artist:".bright_green(), song.artist);
+        println!("{}      {}", "Album:".bright_green(), song.album);
 
         let progress_bar_len = if total_seconds > 0 {
             total_seconds as u64
@@ -362,7 +361,7 @@ async fn select_station_interactively() -> Result<Remote> {
         .unwrap()
         .clone();
 
-    writeline!();
+    println!();
 
     Ok(selected_station)
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,13 +3,25 @@ use console::Term;
 use once_cell::sync::Lazy;
 use std::fmt::Display;
 
-pub static STDOUT: Lazy<Term> = Lazy::new(Term::stdout);
+static STDOUT: Lazy<Term> = Lazy::new(Term::stdout);
 
 pub fn enable_color_on_windows() {
     #[cfg(windows)]
     colored::control::set_virtual_terminal(true).unwrap();
 }
 
+pub fn read_char() -> std::io::Result<char> {
+    STDOUT.read_char()
+}
+
+pub fn print_error(error: impl Display) {
+    println!("{} {}", "Error:".bright_red(), error);
+}
+
+/// You should create an instance of `CleanUpHelper` by calling this method when the programs starts.
+///
+/// # The Problem
+///
 /// This program handles keyboard input (adjust volume) by spawning a thread
 /// and calling [console](https://github.com/console-rs/console) crate's `console::Term::stdout().read_char()` in a loop.
 ///
@@ -20,53 +32,11 @@ pub fn enable_color_on_windows() {
 /// 4. Terminal exits "raw" mode and returns to "canonical" mode
 /// 5. The method returns the key you pressed
 ///
-/// Unfortunately this may cause messy terminal output.
-/// See `terminal::writeline!()` and `terminal::create_clean_up_helper()`'s doc.
-pub fn read_char() -> std::io::Result<char> {
-    STDOUT.read_char()
-}
-
-pub fn print_error(error: impl Display) {
-    writeline!("{} {}", "Error:".bright_red(), error);
-}
-
-/// Whenever you want to print something to terminal, use this macro. DO NOT USE Rust's `println!()`.
-///
-/// # The Problem
-///
-/// On Unix-like OS, when `terminal::read_char()` is blocking in a background thread, your terminal will stay in "raw" mode.
-/// If you write something to terminal from another thread, the terminal output will get messy:
+/// Unfortunately, on Unix-like OS, if the program exits accidentally when `terminal::read_char()` is blocking,
+/// your terminal will stay in "raw" mode and the terminal output will get messy:
 ///
 /// - https://github.com/console-rs/console/issues/36
 /// - https://github.com/console-rs/console/issues/136
-///
-/// See `terminal::read_char()`'s doc.
-///
-/// # The Workaround
-///
-/// This macro will move the cursor to the beginning of the line after writing a line, which fixes the bug.
-macro_rules! writeline {
-    () => {
-        let _ = crate::terminal::STDOUT.write_line("\r");
-    };
-    ($($arg:tt)+) => {
-        for line in format!($($arg)+).split("\n") {
-            let line_r = format!("{}\r", line);
-            let _ = crate::terminal::STDOUT.write_line(&line_r);
-        }
-    };
-}
-
-pub(crate) use writeline;
-
-/// You should create an instance of `CleanUpHelper` by calling this method when the programs starts.
-///
-/// # The Problem
-///
-/// On Unix-like OS, if the program exits accidentally when `terminal::read_char()` is blocking,
-/// your terminal will stay in "raw" mode and the terminal output will get messy.
-///
-/// See `terminal::read_char()`'s doc.
 ///
 /// # The Workaround
 ///

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -32,7 +32,7 @@ pub fn print_error(error: impl Display) {
 /// 4. Terminal exits "raw" mode and returns to "canonical" mode
 /// 5. The method returns the key you pressed
 ///
-/// Unfortunately, on Unix-like OS, if the program exits accidentally when `terminal::read_char()` is blocking,
+/// Unfortunately, on Unix-like OS, if the program exits accidentally when `console::Term::stdout().read_char()` is blocking,
 /// your terminal will stay in "raw" mode and the terminal output will get messy:
 ///
 /// - https://github.com/console-rs/console/issues/36


### PR DESCRIPTION
In console 0.15.7, read_char() won't break println!() in other threads:

- https://github.com/console-rs/console/pull/165
- https://github.com/console-rs/console/issues/136

`terminal::writeline!()` was a workaround for this problem.
So it's no longer needed.